### PR TITLE
Fox optimizing vae

### DIFF
--- a/SNAP-visual-audio-engine/SNAP-visual-audio-engine.vcxproj
+++ b/SNAP-visual-audio-engine/SNAP-visual-audio-engine.vcxproj
@@ -85,8 +85,10 @@
   <ItemGroup>
     <ClInclude Include="config_module.h" />
     <ClInclude Include="file_input.h" />
+    <ClInclude Include="config_types.h" />
     <ClInclude Include="input_module.h" />
     <ClInclude Include="BlenderToDepthMapDLL.h" />
+    <ClInclude Include="json.hpp" />
     <ClInclude Include="openal_module.h" />
     <ClInclude Include="opencv_module.h" />
     <ClInclude Include="shared_mem_input.h" />

--- a/SNAP-visual-audio-engine/SNAP-visual-audio-engine.vcxproj.filters
+++ b/SNAP-visual-audio-engine/SNAP-visual-audio-engine.vcxproj.filters
@@ -77,5 +77,11 @@
     <ClInclude Include="opencv_module.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="config_types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="json.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/SNAP-visual-audio-engine/config_module.h
+++ b/SNAP-visual-audio-engine/config_module.h
@@ -1,28 +1,21 @@
 #pragma once
-#include <string>
 
-using namespace std;
+#include "config_types.h"
+#include "json.hpp"
 
-class config_module
-{
-private:
-	int sourceResolutionVal;
-	int fieldOfViewVal;
-	float frequencyVal;
-	int horizontalStepsVal;
-	float freqIncrementVal;
-	int stepDelayVal;
-	float audioSpreadDegVal;
-	float audioVolRollOffVal;
-public:
-	config_module();
-	void load(string filePath);
-	int sourceResolution();
-	int fieldOfView();
-	float frequency();
-	int horizontalSteps();
-	float freqIncrement();
-	int stepDelay();
-	float audioSpreadDeg();
-	float audioVolRollOff();
-};
+namespace config {
+
+config_type load(std::string filePath);
+bool iequals(const std::string a, const std::string b);
+int string_in_array(const std::string str, const std::string* arr, int arrSize);
+bool is_scantype(std::string str);
+bool is_soundgradient(std::string str);
+bool is_number(nlohmann::json jsonConfig, std::string name);
+bool is_string(nlohmann::json jsonConfig, std::string name);
+void set_int_config(nlohmann::json jsonConfig, std::string name, int &destination);
+void set_float_config(nlohmann::json jsonConfig, std::string name, float &destination);
+void set_scantype_config(nlohmann::json jsonConfig, std::string name, ScanType &destination);
+void set_soundgradient_config(nlohmann::json jsonConfig, std::string name, SoundGradient &destination);
+
+void print(config_type config);
+}

--- a/SNAP-visual-audio-engine/config_module.h
+++ b/SNAP-visual-audio-engine/config_module.h
@@ -4,7 +4,8 @@
 #include "json.hpp"
 
 namespace config {
-
+// TODO: validate each input to make sure it's within a reasonable range
+// such as 0 - 16 for verticalResolution.
 config_type load(std::string filePath);
 bool iequals(const std::string a, const std::string b);
 int string_in_array(const std::string str, const std::string* arr, int arrSize);

--- a/SNAP-visual-audio-engine/config_types.h
+++ b/SNAP-visual-audio-engine/config_types.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string>
+
+namespace config {
+
+const int scanTypeStringsCount = 6;
+
+typedef enum ScanType {
+	LATERAL_RIGHT,
+	LATERAL_LEFT,
+	BILATERAL,
+	SPLIT_LATERAL_OUT,
+	SPLIT_LATERAL_IN,
+	SPLIT_BILATERAL,
+} ScanType;
+
+const std::string scanTypeStrings[scanTypeStringsCount] = {
+	"LATERAL_RIGHT",
+	"LATERAL_LEFT",
+	"BILATERAL",
+	"SPLIT_LATERAL_OUT",
+	"SPLIT_LATERAL_IN",
+	"SPLIT_BILATERAL"
+};
+
+const int soundGradientCount = 4;
+
+typedef enum SoundGradient {
+	FREQUENCY,
+	SINE_TO_SQUARE,
+	SQUARE_TO_SINE,
+	VOLUME
+} SoundGradient;
+
+const std::string soundGradientStrings[soundGradientCount] = {
+	"FREQUENCY",
+	"SINE_TO_SQUARE",
+	"SQUARE_TO_SINE",
+	"VOLUME"
+};
+
+typedef struct config_type {
+	int horizontalResolution;
+	int verticalResolution;
+	int cycleLength;
+	float fieldOfView;
+	float sampleLength;
+	float amplitude;
+	float frequencyMin;
+	float frequencyMax;
+	ScanType scanType;
+	SoundGradient distanceIndicator;
+	SoundGradient heightIndicator;
+	config_type() {
+		horizontalResolution = 32;
+		verticalResolution = 16;
+		fieldOfView = 90.f;
+		sampleLength = 1.f;
+		amplitude = 1.f;
+		frequencyMin = 110.f;
+		frequencyMax = 440.f;
+		cycleLength = 320;
+		scanType = BILATERAL;
+		distanceIndicator = VOLUME;
+		heightIndicator = FREQUENCY;
+	}
+} config_type;
+}

--- a/SNAP-visual-audio-engine/config_types.h
+++ b/SNAP-visual-audio-engine/config_types.h
@@ -60,7 +60,7 @@ typedef struct config_type {
 		amplitude = 1.f;
 		frequencyMin = 110.f;
 		frequencyMax = 440.f;
-		cycleLength = 320;
+		cycleLength = 1000;
 		scanType = BILATERAL;
 		distanceIndicator = VOLUME;
 		heightIndicator = FREQUENCY;

--- a/SNAP-visual-audio-engine/main.cpp
+++ b/SNAP-visual-audio-engine/main.cpp
@@ -1,5 +1,4 @@
 // This is the main entry point for the application.
-
 #include "stdafx.h"
 #include "visual_audio_algorithm.h"
 #include "file_input.h"
@@ -14,5 +13,5 @@ int main() {
 	file_input *input = new file_input();
 	visual_audio_algorithm algorithm(input);
 	config_module *config = new config_module();
-	algorithm.start(config);
+	algorithm.bilateral(config);
 }

--- a/SNAP-visual-audio-engine/main.cpp
+++ b/SNAP-visual-audio-engine/main.cpp
@@ -1,17 +1,13 @@
 // This is the main entry point for the application.
-#include "stdafx.h"
 #include "visual_audio_algorithm.h"
+#include "config_module.h"
 #include "file_input.h"
-#include <stdlib.h>
-#include <cmath>
-
-#include <iostream>
 
 using namespace std;
 
 int main() {
 	file_input *input = new file_input();
 	visual_audio_algorithm algorithm(input);
-	config_module *config = new config_module();
-	algorithm.bilateral(config);
+	config::config_type configs = config::load("");
+	algorithm.bilateral(configs);
 }

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -90,7 +90,17 @@ openal_module::~openal_module()
 
 // TODO: add the ability to create buffers of varying waveforms
 
-void openal_module::init_sine_buffers(int count, float sampleRate, float amplitude, float frequencyMin, float frequencyMax) {
+/**
+ * @brief      Create an array of buffers that contain a sine wave of increasing frequency.
+ *
+ * @param[in]  count         The number of buffers to create.
+ * @param[in]  length        The length of each buffer in seconds.
+ * @param[in]  sampleRate    The sample rate of each buffer.
+ * @param[in]  amplitude     The amplitude amplitude of each buffer (should be in a range of 0-1).
+ * @param[in]  frequencyMin  The low end of the frequency range.
+ * @param[in]  frequencyMax  The high end of the frequency range.
+ */
+void openal_module::init_sine_buffers(int count, float length, float sampleRate, float amplitude, float frequencyMin, float frequencyMax) {
 	// Calculate frequency increment
 	float freqInc = (frequencyMax - frequencyMin) / count;
 	if (buffers != NULL) {
@@ -98,13 +108,14 @@ void openal_module::init_sine_buffers(int count, float sampleRate, float amplitu
 	}
 	buffers = new ALuint[count];
 	alGenBuffers(count, buffers);
-	short *samples = new short[sampleRate];
+	int sampleSize = sampleRate * length;
+	short *samples = new short[sampleSize];
 	float currFreq = frequencyMin;
 	for (int buffer = 0; buffer < count; buffer++) {
-		for (int i = 0; i < sampleRate; ++i) {
+		for (int i = 0; i < sampleSize; ++i) {
 			samples[i] = ((amplitude * SHRT_MAX) * sin(2 * M_PI * i * currFreq / sampleRate));
 		}
-		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleRate * sizeof(short), sampleRate);
+		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), sampleRate);
 		currFreq += freqInc;
 		al_check_error();
 	}

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -96,11 +96,10 @@ openal_module::~openal_module()
  *
  * @param[in]  count         The number of buffers to create.
  * @param[in]  length        The length of each buffer in seconds.
- * @param[in]  amplitude     The amplitude amplitude of each buffer (should be in a range of 0-1).
  * @param[in]  frequencyMin  The low end of the frequency range.
  * @param[in]  frequencyMax  The high end of the frequency range.
  */
-void openal_module::init_sine_buffers(int count, float length, float amplitude, float frequencyMin, float frequencyMax) {
+void openal_module::init_sine_buffers(int count, float length, float frequencyMin, float frequencyMax) {
 	// Calculate frequency increment
 	float freqInc = (frequencyMax - frequencyMin) / count;
 	if (buffers != NULL) {
@@ -113,7 +112,7 @@ void openal_module::init_sine_buffers(int count, float length, float amplitude, 
 	float currFreq = frequencyMin;
 	for (int buffer = 0; buffer < count; buffer++) {
 		for (int i = 0; i < sampleSize; ++i) {
-			samples[i] = ((amplitude * SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
+			samples[i] = ((SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
 		}
 		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), SAMPLE_RATE);
 		currFreq += freqInc;
@@ -241,14 +240,12 @@ void openal_module::source_move(int source, float deltaTheta, float deltaPhi)
 	al_check_error();
 	float oldTheta = cartesian_to_spherical_theta(oldX, oldY, oldZ);
 	float oldPhi = cartesian_to_spherical_phi(oldX, oldY, oldZ);
-	printf("BEFORE MOVE, x:%f, y:%f, z:%f, theta:%f, phi:%f\n", oldX, oldY, oldZ, rad_to_deg(oldTheta), rad_to_deg(oldPhi));
 	float newTheta = normalize_angle(oldTheta + deltaTheta);
 	float newPhi = normalize_angle(oldPhi + deltaPhi);
 	float newX = 0.f;
 	float newY = 0.f;
 	float newZ = 0.f;
 	spherical_to_cartesian(10.f, newTheta, newPhi, &newX, &newY, &newZ);
-	printf("AFTER MOVE, x:%f, y:%f, z:%f, theta:%f, phi:%f\n", newX, newY, newZ, rad_to_deg(newTheta), rad_to_deg(newPhi));
 	alSource3f(sources[source], AL_POSITION, newX, newY, newZ);
 	al_check_error();
 	// if new position is outside bounds, set new position to bounds
@@ -302,6 +299,7 @@ void openal_module::source_print_position(int source)
 }
 
 float openal_module::cartesian_to_spherical_rho(float x, float y, float z) {
+	// TODO: fix or remove rho...this does not calculate the correct rho.
 	x = zero_threshold(x);
 	y = zero_threshold(y);
 	z = zero_threshold(z);

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -1,10 +1,11 @@
 #define _USE_MATH_DEFINES
 #include <cmath> // Trigonometric functions
-#include "stdafx.h"
-#include "openal_module.h"
 #include <limits.h> // SHRT_MAX
-
 #include <iostream>
+
+#include "openal_module.h"
+
+#define SAMPLE_RATE 44100.f
 
 using namespace std;
 
@@ -95,12 +96,11 @@ openal_module::~openal_module()
  *
  * @param[in]  count         The number of buffers to create.
  * @param[in]  length        The length of each buffer in seconds.
- * @param[in]  sampleRate    The sample rate of each buffer.
  * @param[in]  amplitude     The amplitude amplitude of each buffer (should be in a range of 0-1).
  * @param[in]  frequencyMin  The low end of the frequency range.
  * @param[in]  frequencyMax  The high end of the frequency range.
  */
-void openal_module::init_sine_buffers(int count, float length, float sampleRate, float amplitude, float frequencyMin, float frequencyMax) {
+void openal_module::init_sine_buffers(int count, float length, float amplitude, float frequencyMin, float frequencyMax) {
 	// Calculate frequency increment
 	float freqInc = (frequencyMax - frequencyMin) / count;
 	if (buffers != NULL) {
@@ -108,14 +108,14 @@ void openal_module::init_sine_buffers(int count, float length, float sampleRate,
 	}
 	buffers = new ALuint[count];
 	alGenBuffers(count, buffers);
-	int sampleSize = sampleRate * length;
+	int sampleSize = SAMPLE_RATE * length;
 	short *samples = new short[sampleSize];
 	float currFreq = frequencyMin;
 	for (int buffer = 0; buffer < count; buffer++) {
 		for (int i = 0; i < sampleSize; ++i) {
-			samples[i] = ((amplitude * SHRT_MAX) * sin(2 * M_PI * i * currFreq / sampleRate));
+			samples[i] = ((amplitude * SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
 		}
-		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), sampleRate);
+		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), SAMPLE_RATE);
 		currFreq += freqInc;
 		al_check_error();
 	}

--- a/SNAP-visual-audio-engine/openal_module.h
+++ b/SNAP-visual-audio-engine/openal_module.h
@@ -7,7 +7,7 @@ class openal_module
 public:
 	openal_module(int width, int height, float FOV);
 	~openal_module();
-	void init_sine_buffers(int count, float length, float amplitude, float frequencyMin, float frequencyMax);
+	void init_sine_buffers(int count, float length, float frequencyMin, float frequencyMax);
 	void init_sources(int count);
 	const unsigned int *get_sources();
 	const unsigned int *get_buffers();

--- a/SNAP-visual-audio-engine/openal_module.h
+++ b/SNAP-visual-audio-engine/openal_module.h
@@ -7,7 +7,7 @@ class openal_module
 public:
 	openal_module(int width, int height, float FOV);
 	~openal_module();
-	void init_sine_buffers(int count, float length, float sampleRate, float amplitude, float frequencyMin, float frequencyMax);
+	void init_sine_buffers(int count, float length, float amplitude, float frequencyMin, float frequencyMax);
 	void init_sources(int count);
 	const unsigned int *get_sources();
 	const unsigned int *get_buffers();

--- a/SNAP-visual-audio-engine/openal_module.h
+++ b/SNAP-visual-audio-engine/openal_module.h
@@ -7,7 +7,7 @@ class openal_module
 public:
 	openal_module(int width, int height, float FOV);
 	~openal_module();
-	void init_sine_buffers(int count, float sampleRate, float amplitude, float frequencyMin, float frequencyMax);
+	void init_sine_buffers(int count, float length, float sampleRate, float amplitude, float frequencyMin, float frequencyMax);
 	void init_sources(int count);
 	const unsigned int *get_sources();
 	const unsigned int *get_buffers();

--- a/SNAP-visual-audio-engine/opencv_module.h
+++ b/SNAP-visual-audio-engine/opencv_module.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "opencv2/core/core.hpp"
+#include <opencv2/core/core.hpp>
 
 class opencv_module
 {

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -1,18 +1,13 @@
 #include "visual_audio_algorithm.h"
 #include "openal_module.h"
 #include "opencv_module.h"
-#include <opencv2/core/core.hpp>
-#include <chrono>
 
-// Typedefs used for the delay function.
-typedef std::chrono::high_resolution_clock high_resolution_clock;
-typedef std::chrono::milliseconds milliseconds;
-typedef std::chrono::duration<double> duration;
-typedef std::chrono::time_point<chrono::steady_clock> time_point;
+visual_audio_algorithm::visual_audio_algorithm(input_module *input_module)
+{
+	input = input_module;
+}
 
-void delay(int delayLength, time_point start = high_resolution_clock::now());
-
-int visual_audio_algorithm::start(config_module *config) {
+int visual_audio_algorithm::bilateral(config_module *config) {
 	int width = 36;
 	int height = 16;
 	float FOV = 180;
@@ -28,6 +23,7 @@ int visual_audio_algorithm::start(config_module *config) {
 	}
 	// openCV
 	opencv_module cv(width, height);
+
 	cv.set_current_frame(input->get_frame());
 	int x = 0;
 	float intensity = 0.f;
@@ -66,7 +62,7 @@ int visual_audio_algorithm::start(config_module *config) {
  * @param[in]  delayLength  The delay length the length in milliseconds that you would like to delay for.
  * @param[in]  start        (Optional) The start the time_point where you want to delay from.
  */
-void delay(int delayLength, time_point start) {
+void visual_audio_algorithm::delay(int delayLength, time_point start) {
 	time_point now;
 	duration elapsedTime;
 	do  {

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -1,17 +1,25 @@
-#include "stdafx.h"
 #include "visual_audio_algorithm.h"
 #include "openal_module.h"
 #include "opencv_module.h"
 #include <opencv2/core/core.hpp>
+#include <chrono>
+
+// Typedefs used for the delay function.
+typedef std::chrono::high_resolution_clock high_resolution_clock;
+typedef std::chrono::milliseconds milliseconds;
+typedef std::chrono::duration<double> duration;
+typedef std::chrono::time_point<chrono::steady_clock> time_point;
+
+void delay(int delayLength, time_point start = high_resolution_clock::now());
 
 int visual_audio_algorithm::start(config_module *config) {
-	int width = 180;
+	int width = 36;
 	int height = 16;
 	float FOV = 180;
 	// openAL
 	openal_module al(width, height, FOV);
 	al.init_sources(height);
-	al.init_sine_buffers(height, 44100, 0.2, 110.f, 440.f);
+	al.init_sine_buffers(height, 5.f, 44100, 0.2, 110.f, 440.f);
 	// add buffers to sources
 	for (int i = 0; i < height; i++) {
 		al.source_set_buffer(i, i);
@@ -23,31 +31,46 @@ int visual_audio_algorithm::start(config_module *config) {
 	cv.set_current_frame(input->get_frame());
 	int x = 0;
 	float intensity = 0.f;
+	int delayLength = 10;
+	time_point start;
 	while (1) {
 		for (x = 0; x < width; x++) {
+			start = high_resolution_clock::now();
 			for (int y = 0; y < height; y++) {
 				al.source_set_pos(x, y);
 				intensity = cv.get_intensity(x, y);
-				cout << "intensity: " << intensity << endl;
 				al.source_set_gain(y, intensity);
 			}
 			al.source_print_position(0);
-			Sleep(1);
+			delay(delayLength, start);
 		}
 		cv.set_current_frame(input->get_frame());
 		for (x; x >= 0; x--) {
+			start = high_resolution_clock::now();
 			for (int y = 0; y < height; y++) {
 				al.source_set_pos(x, y);
 				intensity = cv.get_intensity(x, y);
-				cout << "intensity: " << intensity << endl;
 				al.source_set_gain(y, intensity);
 			}
 			al.source_print_position(0);
-			Sleep(1);
+			delay(delayLength, start);
 		}
 		cv.set_current_frame(input->get_frame());
 	}
 	return 0;
 }
 
-//float get_grid_intensity(Mat image, int x, int y);
+/**
+ * @brief      Delay function that waits for delayLength before returning.
+ *
+ * @param[in]  delayLength  The delay length the length in milliseconds that you would like to delay for.
+ * @param[in]  start        (Optional) The start the time_point where you want to delay from.
+ */
+void delay(int delayLength, time_point start) {
+	time_point now;
+	duration elapsedTime;
+	do  {
+		now = high_resolution_clock::now();
+		elapsedTime = now - start;
+	} while (chrono::duration_cast<milliseconds>(elapsedTime).count() < delayLength);
+}

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -2,19 +2,23 @@
 #include "openal_module.h"
 #include "opencv_module.h"
 
+using namespace std::chrono;
+using namespace config;
+// Typedefs used for the delay function, for brevity.
+
 visual_audio_algorithm::visual_audio_algorithm(input_module *input_module)
 {
 	input = input_module;
 }
 
-int visual_audio_algorithm::bilateral(config_module *config) {
+int visual_audio_algorithm::bilateral(config_type config) {
 	int width = 36;
 	int height = 16;
 	float FOV = 180;
 	// openAL
 	openal_module al(width, height, FOV);
 	al.init_sources(height);
-	al.init_sine_buffers(height, 5.f, 44100, 0.2, 110.f, 440.f);
+	al.init_sine_buffers(height, 5.f, 0.2, 110.f, 440.f);
 	// add buffers to sources
 	for (int i = 0; i < height; i++) {
 		al.source_set_buffer(i, i);
@@ -28,7 +32,7 @@ int visual_audio_algorithm::bilateral(config_module *config) {
 	int x = 0;
 	float intensity = 0.f;
 	int delayLength = 10;
-	time_point start;
+	time_point<steady_clock> start;
 	while (1) {
 		for (x = 0; x < width; x++) {
 			start = high_resolution_clock::now();
@@ -62,11 +66,11 @@ int visual_audio_algorithm::bilateral(config_module *config) {
  * @param[in]  delayLength  The delay length the length in milliseconds that you would like to delay for.
  * @param[in]  start        (Optional) The start the time_point where you want to delay from.
  */
-void visual_audio_algorithm::delay(int delayLength, time_point start) {
-	time_point now;
-	duration elapsedTime;
+void visual_audio_algorithm::delay(int delayLength, time_point<steady_clock> start) {
+	time_point<steady_clock> now;
+	duration<double> elapsedTime;
 	do  {
 		now = high_resolution_clock::now();
 		elapsedTime = now - start;
-	} while (chrono::duration_cast<milliseconds>(elapsedTime).count() < delayLength);
+	} while (duration_cast<milliseconds>(elapsedTime).count() < delayLength);
 }

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.h
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.h
@@ -2,15 +2,20 @@
 
 #include "input_module.h"
 #include "config_module.h"
+#include <chrono>
 
 class visual_audio_algorithm
 {
 public:
-	visual_audio_algorithm(input_module *input_module)
-	{
-		input = input_module;
-	}
-	int start(config_module *config);
+	visual_audio_algorithm(input_module *input_module);
+	int bilateral(config_module *config);
 private:
 	input_module *input;
+
+	// Typedefs used for the delay function, for brevity.
+	typedef std::chrono::high_resolution_clock high_resolution_clock;
+	typedef std::chrono::milliseconds milliseconds;
+	typedef std::chrono::duration<double> duration;
+	typedef std::chrono::time_point<chrono::steady_clock> time_point;
+	void delay(int delayLength, time_point start = high_resolution_clock::now());
 };

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.h
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.h
@@ -1,21 +1,15 @@
 #pragma once
 
 #include "input_module.h"
-#include "config_module.h"
+#include "config_types.h"
 #include <chrono>
 
 class visual_audio_algorithm
 {
 public:
 	visual_audio_algorithm(input_module *input_module);
-	int bilateral(config_module *config);
+	int bilateral(config::config_type config);
 private:
 	input_module *input;
-
-	// Typedefs used for the delay function, for brevity.
-	typedef std::chrono::high_resolution_clock high_resolution_clock;
-	typedef std::chrono::milliseconds milliseconds;
-	typedef std::chrono::duration<double> duration;
-	typedef std::chrono::time_point<chrono::steady_clock> time_point;
-	void delay(int delayLength, time_point start = high_resolution_clock::now());
+	void delay(int delayLength, std::chrono::time_point<std::chrono::steady_clock> start = std::chrono::high_resolution_clock::now());
 };


### PR DESCRIPTION
* updated the config module to handle all of the correct configs and verify they are the proper type
 * added cycleLength to be used to standardize the amount of time it takes the sources to move from one side to another.
* added config_types.h to allow other modules to include the types without including json.hpp
* added a delay function to standardize the speed of the audio algorithms
* removed SampleRate as an option for sinewaves, they will always be 44100
*  removed amplitude as a parameter for init_sine_wave, the amplitude can be changed through openAL through a source.
* changed start function in visual audio engine into bilateral and set it up to accept configs properly