### PR TITLE
Fox fixing visual audio

### DIFF
--- a/SNAP-visual-audio-engine/file_input.cpp
+++ b/SNAP-visual-audio-engine/file_input.cpp
@@ -8,7 +8,7 @@ using namespace cv;
 
 cv::Mat file_input::get_frame() {
 	// Get a picture from a file next to the exe called soundtest.jpg
-	char* filename = "C:\\Users\\dusti\\Pictures\\diagonal.jpg";
+	char* filename = "C:\\Users\\dusti\\Pictures\\test.jpg";
 	Mat image;
 	Mat *splitImage = NULL;
 	image = imread(filename, CV_LOAD_IMAGE_GRAYSCALE);   // Read the file

--- a/SNAP-visual-audio-engine/main.cpp
+++ b/SNAP-visual-audio-engine/main.cpp
@@ -10,5 +10,5 @@ int main() {
 	shared_mem_input *input = new shared_mem_input();
 	visual_audio_algorithm algorithm(input);
 	config::config_type configs = config::load("");
-	algorithm.bilateral(configs);
+	algorithm.lateral(configs);
 }

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -109,14 +109,13 @@ void openal_module::init_sine_buffers(int count, float length, float frequencyMi
 	alGenBuffers(count, buffers);
 	int sampleSize = SAMPLE_RATE * length;
 	short *samples = new short[sampleSize];
-	float currFreq = frequencyMin;
-	freqInc = 1.059463; // This is how much of a frequency increase to get to the next note in a 12 note scale.
-	for (int buffer = count - 1; buffer >= 0; buffer--) {
+	float currFreq = frequencyMax;
+	for (int buffer = 0; buffer < count; buffer++) {
 		for (int i = 0; i < sampleSize; ++i) {
 			samples[i] = ((SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
 		}
 		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), SAMPLE_RATE);
-		currFreq = currFreq * freqInc;
+		currFreq -= freqInc;
 		al_check_error();
 	}
 }

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -65,7 +65,7 @@ openal_module::openal_module(int width, int height, float FOV)
 	alcMakeContextCurrent(context);
 	al_check_error();
 	// Set default listener orientation is specifiec by an "at" vector and an "up" vector
-	// y+ = right, x- = forward, z+ = up
+	// +y = right, -x = forward, +z = up
 	// see https://www.openal.org/documentation/OpenAL_Programmers_Guide.pdf
 	// for info on listener orientation section 4.2.1.
 	ALfloat listenerOri[] = { -1.f, 0.f, 0.f, 0.f, 0.f, 1.f };
@@ -263,13 +263,12 @@ void openal_module::source_set_pos(int x, int y) {
 		y = yMax - 1;
 	else if (y < 0)
 		y = 0;
-	// Find the start angle since theta starts at 0 behind the listener
-	// we have to start at an offset to center the FOV infront of the
-	// listener.
-	float startAngle = (((2.f * M_PI) - horizontalFOV) / 2.f);
+	// Find the start angle since theta starts at 0 (-x axis) behind the listener
+	// and we want our x axis to start on the left side of the listener
+	float startAngle = (horizontalFOV / 2.0) + M_PI;
 	// The angle increment is the size (in radians) of each x increment.
 	float angleIncrement = horizontalFOV / xMax;
-	float theta = startAngle + (angleIncrement / 2.f) + (angleIncrement * x);
+	float theta = startAngle - (angleIncrement / 2.0) - (angleIncrement * x);
 	float phi = deg_to_rad(90);
 	float rho = 10.f;
 	// Get the new coordinates in cartesian

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -109,13 +109,13 @@ void openal_module::init_sine_buffers(int count, float length, float frequencyMi
 	alGenBuffers(count, buffers);
 	int sampleSize = SAMPLE_RATE * length;
 	short *samples = new short[sampleSize];
-	float currFreq = frequencyMin;
+	float currFreq = frequencyMax;
 	for (int buffer = 0; buffer < count; buffer++) {
 		for (int i = 0; i < sampleSize; ++i) {
 			samples[i] = ((SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
 		}
 		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), SAMPLE_RATE);
-		currFreq += freqInc;
+		currFreq -= freqInc;
 		al_check_error();
 	}
 }

--- a/SNAP-visual-audio-engine/openal_module.cpp
+++ b/SNAP-visual-audio-engine/openal_module.cpp
@@ -109,13 +109,14 @@ void openal_module::init_sine_buffers(int count, float length, float frequencyMi
 	alGenBuffers(count, buffers);
 	int sampleSize = SAMPLE_RATE * length;
 	short *samples = new short[sampleSize];
-	float currFreq = frequencyMax;
-	for (int buffer = 0; buffer < count; buffer++) {
+	float currFreq = frequencyMin;
+	freqInc = 1.059463; // This is how much of a frequency increase to get to the next note in a 12 note scale.
+	for (int buffer = count - 1; buffer >= 0; buffer--) {
 		for (int i = 0; i < sampleSize; ++i) {
 			samples[i] = ((SHRT_MAX) * sin(2 * M_PI * i * currFreq / SAMPLE_RATE));
 		}
 		alBufferData(buffers[buffer], AL_FORMAT_MONO16, samples, sampleSize * sizeof(short), SAMPLE_RATE);
-		currFreq -= freqInc;
+		currFreq = currFreq * freqInc;
 		al_check_error();
 	}
 }

--- a/SNAP-visual-audio-engine/opencv_module.cpp
+++ b/SNAP-visual-audio-engine/opencv_module.cpp
@@ -1,3 +1,4 @@
+#define _USE_MATH_DEFINES
 #include "opencv_module.h"
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -40,15 +41,22 @@ float opencv_module::get_intensity(int x, int y)
 	try
 	{
 		Mat regionOfInterest(currentFrame, Rect(ROIWidth * x, ROIHeight * y, ROIWidth, ROIHeight));
-		Scalar avgPixelIntensity = mean(regionOfInterest);
+
+		Scalar avgPixelIntensity = cv::mean(regionOfInterest);
 		// Get the pixel intensity and normalize it to range (0.0-1.0)
-		intensity = (float)avgPixelIntensity.val[0] / 255.f;
-		// Calculate the normal Rolloff
-		intensity = exp(6.908 * intensity) / 1000;
+		intensity = (float)avgPixelIntensity.val[0] / 255.0;
 	}
 	catch (cv::Exception & e)
 	{
 		std::cerr << e.msg << std::endl; // output exception message
 	}
 	return intensity;
+}
+
+float opencv_module::rolloff(float x, float base) {
+	return (pow(base, x) - 1.0) / (base - 1.0);
+}
+
+float opencv_module::logarithmic_rolloff(float x) {
+	return rolloff(x, M_E);
 }

--- a/SNAP-visual-audio-engine/opencv_module.cpp
+++ b/SNAP-visual-audio-engine/opencv_module.cpp
@@ -23,28 +23,28 @@ void opencv_module::set_current_frame(cv::Mat frame)
 float opencv_module::get_intensity(int x, int y)
 {
 	float intensity = 0.f;
-		// Make sure x and y are within bounds
-		if (x >= xMax)
-			x = xMax - 1;
-		else if (x < 0)
-			x = 0;
-		if (y >= yMax)
-			y = yMax - 1;
-		else if (y < 0)
-			y = 0;
-		// Calculate region of interest dimensions from new frame
-		int ROIWidth = currentFrame.cols / xMax;
-		int ROIHeight = currentFrame.rows / yMax;
-		// Find the intensity at x and y
-		try
-		{
-				Mat regionOfInterest(currentFrame, Rect(ROIWidth * x, ROIHeight * y, ROIWidth, ROIHeight));
-				Scalar avgPixelIntensity = mean(regionOfInterest);
-				intensity = (float)avgPixelIntensity.val[0] / 255.f;
-		}
-		catch (cv::Exception & e)
-		{
-			std::cerr << e.msg << std::endl; // output exception message
-		}
+	// Make sure x and y are within bounds
+	if (x >= xMax)
+		x = xMax - 1;
+	else if (x < 0)
+		x = 0;
+	if (y >= yMax)
+		y = yMax - 1;
+	else if (y < 0)
+		y = 0;
+	// Calculate region of interest dimensions from new frame
+	int ROIWidth = currentFrame.cols / xMax;
+	int ROIHeight = currentFrame.rows / yMax;
+	// Find the intensity at x and y
+	try
+	{
+		Mat regionOfInterest(currentFrame, Rect(ROIWidth * x, ROIHeight * y, ROIWidth, ROIHeight));
+		Scalar avgPixelIntensity = mean(regionOfInterest);
+		intensity = (float)avgPixelIntensity.val[0] / 255.f;
+	}
+	catch (cv::Exception & e)
+	{
+		std::cerr << e.msg << std::endl; // output exception message
+	}
 	return intensity;
 }

--- a/SNAP-visual-audio-engine/opencv_module.cpp
+++ b/SNAP-visual-audio-engine/opencv_module.cpp
@@ -44,7 +44,7 @@ float opencv_module::get_intensity(int x, int y)
 
 		Scalar avgPixelIntensity = cv::mean(regionOfInterest);
 		// Get the pixel intensity and normalize it to range (0.0-1.0)
-		intensity = (float)avgPixelIntensity.val[0] / 255.0;
+		intensity = (float)avgPixelIntensity.val[0] / 65535.0;
 	}
 	catch (cv::Exception & e)
 	{

--- a/SNAP-visual-audio-engine/opencv_module.cpp
+++ b/SNAP-visual-audio-engine/opencv_module.cpp
@@ -2,6 +2,7 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <iostream>
+#include <cmath>
 using namespace cv;
 
 opencv_module::opencv_module(int width, int height)
@@ -40,7 +41,10 @@ float opencv_module::get_intensity(int x, int y)
 	{
 		Mat regionOfInterest(currentFrame, Rect(ROIWidth * x, ROIHeight * y, ROIWidth, ROIHeight));
 		Scalar avgPixelIntensity = mean(regionOfInterest);
+		// Get the pixel intensity and normalize it to range (0.0-1.0)
 		intensity = (float)avgPixelIntensity.val[0] / 255.f;
+		// Calculate the normal Rolloff
+		intensity = exp(6.908 * intensity) / 1000;
 	}
 	catch (cv::Exception & e)
 	{

--- a/SNAP-visual-audio-engine/opencv_module.cpp
+++ b/SNAP-visual-audio-engine/opencv_module.cpp
@@ -41,7 +41,6 @@ float opencv_module::get_intensity(int x, int y)
 	try
 	{
 		Mat regionOfInterest(currentFrame, Rect(ROIWidth * x, ROIHeight * y, ROIWidth, ROIHeight));
-
 		Scalar avgPixelIntensity = cv::mean(regionOfInterest);
 		// Get the pixel intensity and normalize it to range (0.0-1.0)
 		intensity = (float)avgPixelIntensity.val[0] / 65535.0;

--- a/SNAP-visual-audio-engine/opencv_module.h
+++ b/SNAP-visual-audio-engine/opencv_module.h
@@ -7,6 +7,8 @@ public:
 	opencv_module(int width, int height);
 	void set_current_frame(cv::Mat frame);
 	float get_intensity(int x, int y);
+	static float opencv_module::rolloff(float x, float base);
+	static float opencv_module::logarithmic_rolloff(float x);
 private:
 	//
 	cv::Mat currentFrame;

--- a/SNAP-visual-audio-engine/shared_mem_input.cpp
+++ b/SNAP-visual-audio-engine/shared_mem_input.cpp
@@ -11,6 +11,8 @@ cv::Mat shared_mem_input::get_frame()
 	Mat image;
 	int width, height;
 	// Get the dimensions of the image
+	// TODO: have ReadSharedMemorySpace return null if there is nothing to read,
+	// so we know to end the program gracefully instead of a crash.
 	void* ptrToSharedMemory = ReadSharedMemorySpace(width, height);
 	int sizeOfImage = width * height * 4;
 	// Delete the previous image if it exists
@@ -20,7 +22,7 @@ cv::Mat shared_mem_input::get_frame()
 	// Copy the new image from shared memory
 	data = new int[sizeOfImage];
 	memcpy(data, (char*)ptrToSharedMemory, sizeOfImage);
-	image = Mat(height, width, CV_16UC2, data);
+	image = Mat(height, width, CV_8UC2, data);
 	UnmapPointerToSharedMemory((int*)ptrToSharedMemory);
 	// Check for invalid input
 	if (!image.data)

--- a/SNAP-visual-audio-engine/shared_mem_input.cpp
+++ b/SNAP-visual-audio-engine/shared_mem_input.cpp
@@ -22,7 +22,7 @@ cv::Mat shared_mem_input::get_frame()
 	// Copy the new image from shared memory
 	data = new int[sizeOfImage];
 	memcpy(data, (char*)ptrToSharedMemory, sizeOfImage);
-	image = Mat(height, width, CV_8UC2, data);
+	image = Mat(height, width, CV_16UC2, data);
 	UnmapPointerToSharedMemory((int*)ptrToSharedMemory);
 	// Check for invalid input
 	if (!image.data)

--- a/SNAP-visual-audio-engine/shared_mem_input.cpp
+++ b/SNAP-visual-audio-engine/shared_mem_input.cpp
@@ -1,7 +1,5 @@
 #include "shared_mem_input.h"
 #include "SharedMemoryDLL.h"
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
 #include <iostream>
 
 using namespace cv;

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -65,7 +65,6 @@ int visual_audio_algorithm::lateral(config_type config) {
 				al.source_set_pos(x, y);
 				al.source_set_gain(y, intensity);
 			}
-			al.source_print_position(0);
 			delay(delayLength, start);
 		}
 	}

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -33,34 +33,22 @@ int visual_audio_algorithm::bilateral(config_type config) {
 	}
 	// openCV
 	opencv_module cv(config.horizontalResolution, config.verticalResolution);
-	cv.set_current_frame(input->get_frame());
 	float intensity = 0.f;
 	int delayLength = config.cycleLength / config.horizontalResolution;
 	time_point<steady_clock> start;
 	int x = 0;
 	while (1) {
+		cv.set_current_frame(input->get_frame());
 		for (x = 0; x < config.horizontalResolution; x++) {
 			start = high_resolution_clock::now();
 			for (int y = 0; y < config.verticalResolution; y++) {
-				al.source_set_pos(x, y);
 				intensity = cv.get_intensity(x, y);
+				intensity = opencv_module::logarithmic_rolloff(intensity);
+				al.source_set_pos(x, y);
 				al.source_set_gain(y, intensity);
 			}
-			al.source_print_position(0);
 			delay(delayLength, start);
 		}
-		cv.set_current_frame(input->get_frame());
-		for (x; x >= 0; x--) {
-			start = high_resolution_clock::now();
-			for (int y = 0; y < config.verticalResolution; y++) {
-				al.source_set_pos(x, y);
-				intensity = cv.get_intensity(x, y);
-				al.source_set_gain(y, intensity);
-			}
-			al.source_print_position(0);
-			delay(delayLength, start);
-		}
-		cv.set_current_frame(input->get_frame());
 	}
 	return 0;
 }

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.cpp
@@ -1,7 +1,6 @@
 #include "visual_audio_algorithm.h"
 #include "openal_module.h"
 #include "opencv_module.h"
-#include <windows.h>
 
 using namespace std::chrono;
 using namespace config;

--- a/SNAP-visual-audio-engine/visual_audio_algorithm.h
+++ b/SNAP-visual-audio-engine/visual_audio_algorithm.h
@@ -8,7 +8,7 @@ class visual_audio_algorithm
 {
 public:
 	visual_audio_algorithm(input_module *input_module);
-	int bilateral(config::config_type config);
+	int lateral(config::config_type config);
 private:
 	input_module *input;
 	void delay(int delayLength, std::chrono::time_point<std::chrono::steady_clock> start = std::chrono::high_resolution_clock::now());


### PR DESCRIPTION
* Fixed the inverted axes in the opencv module and openal module
* fixed shared_mem_input so that it extracts the greyscale image from the 2 channel image
* added a logarithmic rolloff function to opencv_module for sound
* changed bilateral to lateral and made it work with lateral_left and lateral_right